### PR TITLE
Changes to mobile sizing & spacing

### DIFF
--- a/src/components/DetailsSection.vue
+++ b/src/components/DetailsSection.vue
@@ -110,13 +110,23 @@ $splash-min-width: 600px;
   }
 }
 
-@media (max-width: 480px) {
+
+@media (max-width: 375px) {
+  #details-section{
+    padding: 16px;
+  }
   .se-title, .where-title {
     margin-bottom: 0px;
     margin-top: 0px;
   }
-  .se-date, .where-location {
-    font-size: 0.8em;
+
+  .start-and-end, .where {
+    .se-title, .where-title {
+      font-size: 1.25em;
+    }
+    .se-date, .where-location {
+      font-size: .8em;
+    }
   }
 
   .start-and-end, .where {

--- a/src/components/RegistrationSection.vue
+++ b/src/components/RegistrationSection.vue
@@ -108,6 +108,17 @@ export default {
     }
 }
 
+/* All Mobile Sizes (devices and browser) */
+@media only screen and (max-width: 480px) {
+  .eightbit-btn {
+    font-size: 12px;
+    padding: 10px;
+  }
+  .info-term {
+    font-size: 10px;
+  }
+}
+
 }
 
 .info-term {


### PR DESCRIPTION
On some mobile screens the "Register" group section was spilling out of the full screen.

I prefer to see the full Details + Register section all on one section. The media query for one is a bit odd because the spacing only needs to be changed for *really* tiny phones like iPhone 5